### PR TITLE
Clear cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 yarn-error.log
 .env
 notion-translate.json
+out

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,10 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, rmdir, writeFile, readdir } from "fs/promises";
 
 import { Client } from "@notionhq/client";
 import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 
 import { get_database, query_database } from "./api";
-import { exists } from "./util/fs";
+import { delete_dir, exists } from "./util/fs";
 import { Option, none, some } from "./util/option";
 import { Result, err, ok } from "./util/result";
 
@@ -49,6 +49,15 @@ export class GenCache {
             await mkdir(cache_dir, { recursive: true });
         }
         await writeFile(path, JSON.stringify(this.#data, undefined, 4));
+    }
+
+    static async delete() {
+        if (await exists(cache_dir)) {
+            const res = await delete_dir(cache_dir);
+            if (res.isErr()) {
+                console.error("Failed to delete cache directory:", res.error);
+            }
+        }
     }
 
     get(id: string): Option<CacheEntry> {

--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -1,3 +1,4 @@
+import { GenCache } from "../cache";
 import { Config } from "../config";
 
 interface InitOptions {
@@ -11,11 +12,15 @@ export function init(options: InitOptions, config: Config) {
 
 interface CleanOptions {
     all: boolean;
+    cache: boolean;
 }
 export async function clean(options: CleanOptions) {
     if (options.all) {
         await Config.rm();
     }
 
+    if (options.cache) {
+        await GenCache.delete();
+    }
     process.exit(0);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,8 +51,9 @@ export default async function main(): Promise<number> {
         });
 
     app.command("clean")
-        .description("Cleans all temporary files")
-        .option("-a, --all", "Also remove all config files")
+        .description("Cleans all temporary files and cache")
+        .option("-a, --all", "Also remove all config files and cache files")
+        .option("-c, --no-cache", "Don't clear cache files")
         .action(async (options) => await Util.clean(options));
 
     const local = app

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -1,5 +1,8 @@
 import { constants } from "fs";
-import { access, writeFile } from "fs/promises";
+import { access, writeFile, rm, rmdir, readdir, stat } from "fs/promises";
+import { join } from "path";
+
+import { Result, err, ok } from "./result";
 
 export async function exists(path: string): Promise<boolean> {
     try {
@@ -12,4 +15,31 @@ export async function exists(path: string): Promise<boolean> {
 
 export async function save(path: string, contents: string) {
     await writeFile(path, contents, { encoding: "utf8" });
+}
+
+export async function delete_dir(path: string): Promise<Result<null, Error>> {
+    const entries = await readdir(path);
+    for (const entry of entries) {
+        const p = join(path, entry);
+        const stats = await stat(p);
+        if (stats.isDirectory()) {
+            const res = await delete_dir(p);
+            if (res.isErr()) {
+                return res;
+            }
+            continue;
+        }
+        try {
+            await rm(p);
+        } catch (e) {
+            return err(e as Error);
+        }
+    }
+    try {
+        await rmdir(path);
+    } catch (e) {
+        return err(e as Error);
+    }
+
+    return ok(null);
 }


### PR DESCRIPTION
Extends the `clean` command to also delete the cache.
This can be disabled by running clean with the `--no-cache` flag.

Closes #10 